### PR TITLE
Error responses

### DIFF
--- a/src/commands/jisho.js
+++ b/src/commands/jisho.js
@@ -8,7 +8,7 @@ module.exports = function command(requires)
     name: 'Jisho',
     inline: false,
     alias: ['j'],
-    description: '[<word/sentence>, <word/sentence> --list, <word/sentence> <number from --list>] Looks up a word from Jisho.org, you may use jisho <word> --list to get a list of definitions. Then use jisho <word> <number> and that will display the definition',
+    description: '[<word/sentence>, <word/sentence> --list, <word/sentence> <number from --list>] Looks up a word from Jisho.org, you may use jisho <word> --list to get a list of dictionary entries. Then use jisho <word> <number> and that will display that entry',
     permission: 'public',
     action: function(details)
     {
@@ -64,7 +64,7 @@ module.exports = function command(requires)
             }
           });
         });
-      }
+      };
       //processes the command
       //to better understand this part, take a look at the parameters at the top of the page
       if(details.input === '') {return;}

--- a/src/feathers/jishoAPI/jishoAPI.js
+++ b/src/feathers/jishoAPI/jishoAPI.js
@@ -20,7 +20,7 @@ module.exports = function feather(requires)
         resolve(prettyDisplay(data, num));
       }).catch(reject);
     });
-  }
+  };
   feather.listJisho = function(word, dmBool)
   {
     return new Promise((resolve, reject) =>
@@ -30,7 +30,7 @@ module.exports = function feather(requires)
         resolve(listJapanese(data,dmBool));
       }).catch(reject);
     });
-  }
+  };
   //helper functions
   const jishoReq = function(word)
   {
@@ -50,7 +50,7 @@ module.exports = function feather(requires)
           }
         }).catch(reject);
     });
-  }
+  };
   //list the japanese readings
   const listJapanese = function(api, dmBool)
   {
@@ -68,7 +68,7 @@ module.exports = function feather(requires)
       }
       list += line;
     }
-    emb.description = list + '\nUse jisho(j) <word> <number on list> to get that definition';
+    emb.description = list + '\nUse jisho(j) <word> <number on list> to get that entry';
     if(!dmBool && dataLen > 10)
     {
       emb.footer = {text: 'You have been DMed due to the amount of results'};
@@ -193,10 +193,10 @@ module.exports = function feather(requires)
       }
       else if(num >= api.data.length)
       {
-        let v = 'There aren\'t enough entries in the dictionary to grab number ' + (num+1)+'.'
+        let v = 'There aren\'t enough entries in the dictionary to grab number ' + (num+1)+'.';
         if(api.data.length == 1)
         {
-          v += 'There is only one entry'
+          v += 'There is only one entry';
         }
         else
         {

--- a/src/feathers/jishoAPI/jishoAPI.js
+++ b/src/feathers/jishoAPI/jishoAPI.js
@@ -185,9 +185,24 @@ module.exports = function feather(requires)
     let fields = [];
     try
     {
-      if(api.data[num] == undefined)
+      if(api.meta === undefined || api.meta.status != 200) {
+        throw 'Bad API response';
+      } if(api.data.length == 0)
       {
-        throw 'api.data is undefined';
+        fields = [{name: 'Error', value:'No results found for this query, it may not exist in the dictionary. Check on jisho.org; if it does exist there, please contact CyberRonin', inline:true}];
+      }
+      else if(num >= api.data.length)
+      {
+        let v = 'There aren\'t enough entries in the dictionary to grab number ' + (num+1)+'.'
+        if(api.data.length == 1)
+        {
+          v += 'There is only one entry'
+        }
+        else
+        {
+          v += 'There are only  '+(api.data.length)+' entry.';
+        }
+        fields = [{name: 'Error', value:v, inline:true}];
       }
       else
       {


### PR DESCRIPTION
- Changes the response for when the data array in the API response is empty. It now assumes the request is working correctly (but still warns to check if results are found on the actual jisho website, and if they are, contact the dev)
- Also considers the case of putting a number too large for the amount of results gotten from the api (such as `!j かわいい 35`, saying how many results there are actually are
- Adds a check for the the response status code not being 200.
- I also changed the wording to refer to each result you can get in the `!j <word> <number>` command as _entries_ and not _definitions_. I've seen someone get confused thinking the number brought up a single definition within a dictionary entry (eg: `!j かわいい 3` to bring up `3. innocent; childlike; childish; lovable​` from the first かわいい result). This is actually a potentially interesting feature, which can be used to bring up a specific usage to someone asking what a word means in context, but for now I just changed the wording to make it a bit clearer.
