### PR TITLE
Help command revamp

### DIFF
--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -8,7 +8,9 @@ module.exports = function command(requires)
     name: 'Debug',
     inline: true,
     alias: ['ev'],
-    description: 'Evaluates JS code',
+    blurb: 'Evaluates JS code', 
+    longDescription: '', 
+    usages: ['`!ev {javascript code}` ― Executes code '], 
     permission: 'private',
     action: function(details)
     {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -23,7 +23,7 @@ module.exports = function command(requires)
       emb.description = "You can DM the bot :heart:";
       
       const listCommands = function()
-      {
+      {        
         emb.title = 'Help';
         emb.blurb = "You can DM the bot :heart:";
         Object.keys(info.commands).forEach((commandName,index) => {
@@ -36,9 +36,13 @@ module.exports = function command(requires)
           }
           //create the entry in the embed
           let prefix = info.config.prefix;
-          let aliases = prefix + command.getAlias().join(', ' + prefix);
+          let aliases = '';
+          if(command.getAlias()){
+            let separator = ', ' + prefix;
+            aliases = separator + command.getAlias().join(separator);
+          }
           let field = {};
-          field.name = `${prefix}${commandName}, ${aliases}`;
+          field.name = `${prefix}${commandName}${aliases}`;
           field.value = command.blurb;
           field.inline = false; //info.commands[command].inline;
           emb.fields.push(field);
@@ -63,16 +67,13 @@ module.exports = function command(requires)
         } else {
           emb.title = 'Info: ' + command.name;
           emb.description = command.blurb;
-          let fieldIdx = 0;
-          if(command.longDescription != '') {       
-            emb.fields[field] = {
-              name: 'Description:',
-              value: command.longDescription
-            };
-            fieldIdx += 1;
+          let fieldIdx = 0;    
+          emb.fields[fieldIdx] = {
+            name: 'Description:',
+            value: command.longDescription || 'No description'
           };
           if(command.usages) {
-            emb.fields[fieldIdx] = {
+            emb.fields[1] = {
               name: 'Usages:',
               value: command.usages.join('\n')
             };            

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -10,7 +10,8 @@ module.exports = function command(requires)
     alias: ['?', 'h'],
     blurb: 'See function and usage of each command',
     longDescription: 'See usage details for commands or bring up a list of available commands',
-    usages: ['`!help` ― Shows list of commands with short descriptions', '`!help {command}` ― Shows full help message for a specific command'],
+    usages: ['`!help` ― Shows list of commands with short descriptions',
+             '`!help {command}` ― Shows full help message for a specific command'],
     permission: 'public',
     action: function(details)
     {
@@ -68,9 +69,9 @@ module.exports = function command(requires)
           let fieldIdx = 0;    
           emb.fields[fieldIdx] = {
             name: 'Description:',
-            value: command.longDescription || 'No description'
+            value: command.longDescription
           };
-          if(command.usages) {
+          if(command.usages.length > 0) {
             emb.fields[1] = {
               name: 'Usages:',
               value: command.usages.join('\n')

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -22,20 +22,18 @@ module.exports = function command(requires)
       emb.title = 'Help';
       emb.description = "You can DM the bot :heart:";
       
-      const listCommands = function()
+      const listCommands = function(userLevel)
       {        
         emb.title = 'Help';
         emb.blurb = "You can DM the bot :heart:";
         Object.keys(info.commands).forEach((commandName,index) => {
           let command = info.commands[commandName];
-          let commandLevel = command.getPerm();
-          // details.permissionLevel should have the user's permission level
-          // see bot.js `processCommand`         
-          if(!utility.hasPermission(commandLevel, details.permissionLevel)) {
+          let commandLevel = command.getPerm();                
+          if(!utility.hasPermission(commandLevel, userLevel)) {
             return;
           }
           //create the entry in the embed
-          let prefix = info.config.prefix;
+          const prefix = info.config.prefix;
           let aliases = '';
           if(command.getAlias()){
             let separator = ', ' + prefix;
@@ -53,11 +51,11 @@ module.exports = function command(requires)
         });     
       };
       
-      const sendDetails = function(commandName)
+      const sendDetails = function(commandName, userLevel)
       {
         let command = utility.getCommand(commandName);
         if(command == null
-           || !utility.hasPermission(command.getPerm(), details.permissionLevel)) {
+           || !utility.hasPermission(command.getPerm(), userLevel)) {
           bot.createMessage(details.channelID, {
             embed: {
               title: 'No Such Command',
@@ -83,12 +81,15 @@ module.exports = function command(requires)
           });
         }
       };
+      
+      utility.getPermLevel(details).then((userLevel) => {        
+        if(details.input === '') {
+          listCommands(userLevel);
+        } else {
+          sendDetails(details.input, userLevel);
+        }      
+      }).catch(console.log);
 
-      if(details.input === '') {
-        listCommands();
-      } else {
-        sendDetails(details.input);
-      }      
     }
   }, requires);
 };

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -8,8 +8,8 @@ module.exports = function command(requires)
     name: 'Help',
     inline: true,
     alias: ['?', 'h'],
-    blurb: 'See usage details for commands with `!help <command>` or bring up a list of available commands',
-    longDescription: '',
+    blurb: 'See function and usage of each command',
+    longDescription: 'See usage details for commands or bring up a list of available commands',
     usages: ['`!help` ― Shows list of commands with short descriptions', '`!help {command}` ― Shows full help message for a specific command'],
     permission: 'public',
     action: function(details)

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -8,56 +8,86 @@ module.exports = function command(requires)
     name: 'Help',
     inline: true,
     alias: ['?', 'h'],
-    description: 'Brings up this menu.',
+    blurb: 'See usage details for commands with `!help <command>` or bring up a list of available commands',
+    longDescription: '',
+    usages: ['`!help` ― Shows list of commands with short descriptions', '`!help {command}` ― Shows full help message for a specific command'],
     permission: 'public',
     action: function(details)
     {
       let bot = requires.bot;
       let info = requires.info;
+      let utility = info.utility;
       let emb = {};
       emb.fields = [];
       emb.title = 'Help';
       emb.description = "You can DM the bot :heart:";
-      let permPromise;
-      if(details.member) {
-        permPromise = info.db.findPerm(details.userID, details.member.roles);
-      } else {
-        permPromise = info.db.findPerm(details.userID, []);
-      }
-      permPromise.then(perm => {
-        let permissionLevel
-        if(perm === null) {
-          permissionLevel = 'none';
-        } else {
-          permissionLevel = perm._id;
-        }
-        Object.keys(info.commands).forEach((command,index) =>
-        {
-          let field = {};
-          //Looks to see if it's an admin comand. If it is, don't display the info.
-          if(info.commands[command].getPerm() === 'private' && !details.isAdministrator)
-          {
-            return;
-          } else if(info.commands[command].getPerm() === 'high' && (!details.isAdministrator && permissionLevel !== 'high')) {
-            return;
-          } else if(info.commands[command].getPerm() === 'low' && (!details.isAdministrator && permissionLevel !== 'high' && permissionLevel !== 'low')) {
+      
+      const listCommands = function()
+      {
+        emb.title = 'Help';
+        emb.blurb = "You can DM the bot :heart:";
+        Object.keys(info.commands).forEach((commandName,index) => {
+          let command = info.commands[commandName];
+          let commandLevel = command.getPerm();
+          // details.permissionLevel should have the user's permission level
+          // see bot.js `processCommand`         
+          if(!utility.hasPermission(commandLevel, details.permissionLevel)) {
             return;
           }
           //create the entry in the embed
           let prefix = info.config.prefix;
-          let aliases = prefix + info.commands[command].getAlias().join(', ' + prefix);      
-          field.name = `${prefix}${command}, ${aliases}`;
-          field.value = info.commands[command].getDesc();
-          field.inline = info.commands[command].inline;
+          let aliases = prefix + command.getAlias().join(', ' + prefix);
+          let field = {};
+          field.name = `${prefix}${commandName}, ${aliases}`;
+          field.value = command.blurb;
+          field.inline = false; //info.commands[command].inline;
           emb.fields.push(field);
         });
-        
         //seeeeend it once all of the commands are iterated through
         bot.createMessage(details.channelID, {
           embed: emb
-        });
-      })
+        });     
+      };
+      
+      const sendDetails = function(commandName)
+      {
+        let command = utility.getCommand(commandName);
+        if(command == null
+           || !utility.hasPermission(command.getPerm(), details.permissionLevel)) {
+          bot.createMessage(details.channelID, {
+            embed: {
+              title: 'No Such Command',
+              description: 'Command could not be found or you do not have permission to use this command'
+            }            
+          });
+        } else {
+          emb.title = 'Info: ' + command.name;
+          emb.description = command.blurb;
+          let fieldIdx = 0;
+          if(command.longDescription != '') {       
+            emb.fields[field] = {
+              name: 'Description:',
+              value: command.longDescription
+            };
+            fieldIdx += 1;
+          };
+          if(command.usages) {
+            emb.fields[fieldIdx] = {
+              name: 'Usages:',
+              value: command.usages.join('\n')
+            };            
+          }
+          bot.createMessage(details.channelID, {
+            embed: emb
+          });
+        }
+      };
 
+      if(details.input === '') {
+        listCommands();
+      } else {
+        sendDetails(details.input);
+      }      
     }
   }, requires);
 };

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -44,7 +44,7 @@ module.exports = function command(requires)
           let field = {};
           field.name = `${prefix}${commandName}${aliases}`;
           field.value = command.blurb;
-          field.inline = false; //info.commands[command].inline;
+          field.inline = true; //info.commands[command].inline;
           emb.fields.push(field);
         });
         //seeeeend it once all of the commands are iterated through

--- a/src/commands/jisho.js
+++ b/src/commands/jisho.js
@@ -8,7 +8,9 @@ module.exports = function command(requires)
     name: 'Jisho',
     inline: false,
     alias: ['j'],
-    description: '[<word/sentence>, <word/sentence> --list, <word/sentence> <number from --list>] Looks up a word from Jisho.org, you may use jisho <word> --list to get a list of dictionary entries. Then use jisho <word> <number> and that will display that entry',
+    blurb: 'Looks up word using Jisho API',
+    longDescription: 'Searches [Jisho](jisho.org) API for word definitions. Can search with both English and Japanese input, the interpretation of the input is left for jisho. \nBy default this returns the first result only, which may not always be what you want. You can grab results further down the list by adding a number after the word. You can get a list of results by adding `--list`. \nThis is especially useful when searching English words, as often the top result may not be what you actually want',
+    usages: ['`!jisho {word}` ― Returns top result for this word in the dictionary', '`!jisho {word} --list` ― Returns a list of all results from this lookup', '`!j {word} {number}` ― Return {number}th result for this word'],
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/jisho.js
+++ b/src/commands/jisho.js
@@ -10,7 +10,7 @@ module.exports = function command(requires)
     alias: ['j'],
     blurb: 'Looks up word using Jisho API',
     longDescription: 'Searches [Jisho](jisho.org) API for word definitions. Can search with both English and Japanese input, the interpretation of the input is left for jisho. \nBy default this returns the first result only, which may not always be what you want. You can grab results further down the list by adding a number after the word. You can get a list of results by adding `--list`. \nThis is especially useful when searching English words, as often the top result may not be what you actually want',
-    usages: ['`!jisho {word}` ― Returns top result for this word in the dictionary', '`!jisho {word} --list` ― Returns a list of all results from this lookup', '`!j {word} {number}` ― Return {number}th result for this word'],
+    usages: ['`!jisho {word}` ― Returns top result for this word in the dictionary', '`!jisho {word} --list` ― Returns a list of results from this lookup', '`!j {word} {number}` ― Return {number}th result for this word'],
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/kanji.js
+++ b/src/commands/kanji.js
@@ -10,7 +10,7 @@ module.exports = function command(requires)
     alias: ['k'],
     blurb: 'Looks up kanji information.',
     longDescription: 'Retrieves kanji data from kanjidic2. \n Gets info such as kanji meaning, readings, radical, composing elements, and JLPT level.',
-    usages: ['`!kanji {kanji}`'],
+    usages: ['`!kanji {kanji}` ― Returns info on {kanji}'],
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/kanji.js
+++ b/src/commands/kanji.js
@@ -8,7 +8,9 @@ module.exports = function command(requires)
     name: 'Kanji',
     inline: true,
     alias: ['k'],
-    description: '<kanji> , Looks up kanji information.',
+    blurb: 'Looks up kanji information.',
+    longDescription: 'Retrieves kanji data from kanjidic2. \n Gets info such as kanji meaning, readings, radical, composing elements, and JLPT level.',
+    usages: ['`!kanji {kanji}`'],
     permission: 'public',
     action: function(details)
     {
@@ -34,7 +36,7 @@ module.exports = function command(requires)
         });
       };
 
-      if(details.input === "") {return;}
+      if(details.input === '') {return;}
       else
       {
         searchKanji(details.args[1]);

--- a/src/commands/kill.js
+++ b/src/commands/kill.js
@@ -8,7 +8,9 @@ module.exports = function command(requires)
     name: 'Kill',
     inline: true,
     alias: ['ki'],
-    description: 'Kills the bot',
+    blurb: 'Kills the bot', 
+    longDescription: 'Sometimes you just gotta do it ┐(´д｀)┌', 
+    usages: ['!kill'], 
     permission: 'private',
     action: function(details)
     {

--- a/src/commands/loadsettings.js
+++ b/src/commands/loadsettings.js
@@ -8,7 +8,7 @@ module.exports = function command(requires)
     name: 'Load Settings',
     inline: true,
     alias: ['ls'],
-    description: 'Loads the settings to the db',
+    blurb: 'Loads the settings to the db',
     permission: 'private',
     action: function(details)
     {
@@ -23,7 +23,7 @@ module.exports = function command(requires)
           }
         });
         requires.bot.createMessage(details.channelID, {content: 'Settings loaded'});
-      })
+      });
     }
   }, requires);
 };

--- a/src/commands/mute.js
+++ b/src/commands/mute.js
@@ -9,6 +9,7 @@ module.exports = function command(requires)
     inline: true,
     alias: ['m'],
     blurb: 'Mutes people.',
+    usages: ['`!m {user} {time} {reason}`'],
     permission: 'low',
     action: function(details)
     {

--- a/src/commands/mute.js
+++ b/src/commands/mute.js
@@ -8,7 +8,7 @@ module.exports = function command(requires)
     name: 'Mute',
     inline: true,
     alias: ['m'],
-    description: 'Mutes people.',
+    blurb: 'Mutes people.',
     permission: 'low',
     action: function(details)
     {

--- a/src/commands/pencil.js
+++ b/src/commands/pencil.js
@@ -8,7 +8,7 @@ module.exports = function command(requires)
     name: 'Pencil',
     inline: true,
     alias: ['p'],
-    description: 'Adds a pencil at the end of your nickname or username',
+    blurb: 'Adds a pencil at the end of your nickname or username',
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/pencil.js
+++ b/src/commands/pencil.js
@@ -9,7 +9,8 @@ module.exports = function command(requires)
     inline: true,
     alias: ['p'],
     blurb: 'Adds a pencil at the end of your nickname',
-    longDescription: 'Adds a pencil emoji to your nickname, indicating you\'d like to have your messages be proactively corrected.', 
+    longDescription: 'Adds a pencil emoji to your nickname, indicating you\'d like to have your messages be proactively corrected.',
+    usages: ['`!p`'],
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/pencil.js
+++ b/src/commands/pencil.js
@@ -8,7 +8,8 @@ module.exports = function command(requires)
     name: 'Pencil',
     inline: true,
     alias: ['p'],
-    blurb: 'Adds a pencil at the end of your nickname or username',
+    blurb: 'Adds a pencil at the end of your nickname',
+    longDescription: 'Adds a pencil emoji to your nickname, indicating you\'d like to have your messages be proactively corrected.', 
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/randomkanji.js
+++ b/src/commands/randomkanji.js
@@ -8,7 +8,7 @@ module.exports = function command(requires)
     name: 'Random Kanji',
     inline: true,
     alias: ['rk'],
-    description: 'Gets info on random kanji.',
+    blurb: 'Gets info on random kanji.',
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/randomkanji.js
+++ b/src/commands/randomkanji.js
@@ -9,6 +9,7 @@ module.exports = function command(requires)
     inline: true,
     alias: ['rk'],
     blurb: 'Gets info on random kanji.',
+    usages: ['`!rk`'],
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/rapsheet.js
+++ b/src/commands/rapsheet.js
@@ -8,7 +8,7 @@ module.exports = function command(requires)
     name: 'Rapsheet',
     inline: true,
     alias: ['rs'],
-    description: 'Get\'s a user\'s infractions.',
+    blurb: 'Get\'s a user\'s infractions.',
     permission: 'low',
     action: function(details)
     {

--- a/src/commands/setperms.js
+++ b/src/commands/setperms.js
@@ -8,7 +8,7 @@ module.exports = function command(requires)
     name: 'Set Perms',
     inline: true,
     alias: ['sp'],
-    description: 'Adds a role or user ID to the associated perm.',
+    blurb: 'Adds a role or user ID to the associated perm.',
     permission: 'private',
     action: function(details)
     {

--- a/src/commands/setroles.js
+++ b/src/commands/setroles.js
@@ -8,7 +8,9 @@ module.exports = function command(requires)
     name: 'Set Roles',
     inline: true,
     alias: ['sr'],
-    description: 'Sets available user roles.',
+    blurb: 'Sets available user roles for self-assignment.', 
+    longDescription: 'Given a role name, makes it self-assignable. Using it with a role that is already set, will make it no longer be self-assignable.', 
+    usages: ['!sr {role name} ― Toggles whether role is self-assignable'], 
     permission: 'high',
     action: function(details)
     {
@@ -35,15 +37,15 @@ module.exports = function command(requires)
               info.db.removeRoleByID(roleID).then((numRemoved) => {
                 let remEmb = {};
                 remEmb.title = 'Removed';
-                remEmb.description = `You have removed the __${details.input}__ role for the user selectable roles`;
+                remEmb.description = `You have removed the __${details.input}__ role from the user selectable roles`;
                 remEmb.color = info.utility.red;
                 bot.createMessage(details.channelID, {embed: remEmb});
               }).catch((err) => {
                 console.log(err);
-              })
+              });
             }
             console.log(err.errorType);
-          })
+          });
         }).catch((err) =>
         {
           console.log(err);

--- a/src/commands/settags.js
+++ b/src/commands/settags.js
@@ -7,8 +7,10 @@ module.exports = function command(requires)
   return new Command({
     name: 'Set Tags',
     inline: true,
-    alias: ['st'],
-    description: 'Sets available tags.',
+    blurb: 'Stores text for easy retrieval', 
+    longDescription: 'Creates a retrivable message. Don\'t forget the `:` when creating a tag.  Calling without `:` and additional text removes a tag.', 
+    usages: ['!st {tag name}: {text} ― Creates {tag name} tag that will return {text}',
+            '`!st {tag name} ― Removes {tag name}` '], 
     permission: 'low',
     action: function(details)
     {

--- a/src/commands/settags.js
+++ b/src/commands/settags.js
@@ -7,10 +7,11 @@ module.exports = function command(requires)
   return new Command({
     name: 'Set Tags',
     inline: true,
+    alias: ['st'],
     blurb: 'Stores text for easy retrieval', 
     longDescription: 'Creates a retrivable message. Don\'t forget the `:` when creating a tag.  Calling without `:` and additional text removes a tag.', 
     usages: ['!st {tag name}: {text} ― Creates {tag name} tag that will return {text}',
-            '`!st {tag name} ― Removes {tag name}` '], 
+            '`!st {tag name} ― Removes {tag name}`'], 
     permission: 'low',
     action: function(details)
     {

--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -8,7 +8,9 @@ module.exports = function command(requires)
     name: 'Stats',
     inline: true,
     alias: ['s'],
-    description: 'Returns stats on the bot.',
+    blurb: 'Returns stats on the bot.', 
+    longDescription: 'Gets basic info such as uptime.', 
+    usages: ['`!stats`'], 
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/strokeorder.js
+++ b/src/commands/strokeorder.js
@@ -8,7 +8,9 @@ module.exports = function command(requires)
     name: 'Stroke Order',
     inline: true,
     alias: ['so'],
-    description: '<kanji> , Looks up kanji stroke order',
+    blurb: 'Shows the stroke order of a kanji (animated)',
+    longDescription: 'Shows animated stroke order image of given kanji. Also works on kana and some other miscellaneous Japanese characters.',
+    usages: ['`!so {kanji}` ― Returns stroke order of {kanji}.'],
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/tag.js
+++ b/src/commands/tag.js
@@ -8,7 +8,10 @@ module.exports = function command(requires)
     name: 'Tag',
     inline: true,
     alias: ['t'],
-    description: 'Lists tags, or displays the content of a specific tag',
+    blurb: 'Retrieves important texts', 
+    longDescription: 'Lists tags, or displays the content of a specific tag.', 
+    usages: ['!t ― Shows a list of all available tags',
+             '!t {tag name} ― Retrieves {tag name} '], 
     permission: 'public',
     action: function(details)
     {
@@ -21,7 +24,7 @@ module.exports = function command(requires)
         info.db.listTags().then((tagNames) =>
         {
           let emb = {};
-          emb.title = 'Tags.'
+          emb.title = 'Tags.';
           emb.description = tagNames.join('\n');
           bot.createMessage(details.channelID, {embed: emb});
         });

--- a/src/commands/tag.js
+++ b/src/commands/tag.js
@@ -10,8 +10,8 @@ module.exports = function command(requires)
     alias: ['t'],
     blurb: 'Retrieves important texts', 
     longDescription: 'Lists tags, or displays the content of a specific tag.', 
-    usages: ['!t ― Shows a list of all available tags',
-             '!t {tag name} ― Retrieves {tag name} '], 
+    usages: ['`!t` ― Shows a list of all available tags',
+             '`!t {tag name}` ― Retrieves {tag name} '], 
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/userinfo.js
+++ b/src/commands/userinfo.js
@@ -8,7 +8,10 @@ module.exports = function command(requires)
     name: 'User Info',
     inline: false,
     alias: ['ui'],
-    description: '[<mention user>]Gets information for a user that is mentioned, or the person that used the command. If there is no mention, then it will get the information of the person who used the command.',
+    blurb: 'Gets info on a user',
+    longDescription: 'Shows account creation date and server join date for a user. Without a specified user mentioned, gets info on the person who used the command.',
+    usages: ['`!ui` ― Gets info on sender',
+             '`!ui {user}` ― Gets info on specified user.'],
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/userrole.js
+++ b/src/commands/userrole.js
@@ -8,7 +8,7 @@ module.exports = function command(requires)
     name: 'User Role',
     inline: true,
     alias: ['ur'],
-    description: 'Lists roles, or assigns/removes the role searched for',
+    blurb: 'Lists roles, or assigns/removes the role searched for',
     permission: 'public',
     action: function(details)
     {
@@ -20,10 +20,10 @@ module.exports = function command(requires)
       {
         info.db.listRoles().then((roleNames) => {
           let emb = {}; 
-          emb.title = 'User selectable roles.'
+          emb.title = 'User selectable roles.';
           emb.description = roleNames.join('\n');
           bot.createMessage(details.channelID, {embed: emb});
-        })
+        });
       }
       else
       {
@@ -41,8 +41,8 @@ module.exports = function command(requires)
             else
             {
               //if they don't already have the role, give it to them.
-              let memberRoles = bot.guilds.get(details.serverID).members.get(details.userID).roles
-              let roleSearch = memberRoles.find(memberRole => memberRole === roleID)
+              let memberRoles = bot.guilds.get(details.serverID).members.get(details.userID).roles;
+              let roleSearch = memberRoles.find(memberRole => memberRole === roleID);
               if(roleSearch === undefined)
               {
                 bot.guilds.get(details.serverID).members.get(details.userID).addRole(roleID).then((result) =>

--- a/src/commands/userrole.js
+++ b/src/commands/userrole.js
@@ -9,6 +9,8 @@ module.exports = function command(requires)
     inline: true,
     alias: ['ur'],
     blurb: 'Lists roles, or assigns/removes the role searched for',
+    usages: ['`!ur ― List self-assignable roles',
+             '`!ur {role} ― Gives you the role, or removes it if you already have it.`'],
     permission: 'public',
     action: function(details)
     {

--- a/src/commands/userrole.js
+++ b/src/commands/userrole.js
@@ -19,7 +19,7 @@ module.exports = function command(requires)
       if(details.input === "")
       {
         info.db.listRoles().then((roleNames) => {
-          let emb = {};
+          let emb = {}; 
           emb.title = 'User selectable roles.'
           emb.description = roleNames.join('\n');
           bot.createMessage(details.channelID, {embed: emb});

--- a/src/commands/warn.js
+++ b/src/commands/warn.js
@@ -8,7 +8,7 @@ module.exports = function command(requires)
     name: 'Warn',
     inline: true,
     alias: ['w'],
-    description: 'Warns people.',
+    blurb: 'Warns people.',
     permission: 'low',
     action: function(details)
     {

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -124,6 +124,31 @@ module.exports = (requires) => {
   utilities.filter = (str) => {
     return str.replace('%prefix', config.prefix);
   };
+
+  //for finding the command object for either the keyword or an alias 
+  utilities.getCommand = function(keyword) 
+  { 
+    let commands = info.commands; 
+    //if the command exists, check the permissions. 
+    if(commands[keyword] && typeof commands[keyword].getAction() === 'function') 
+    { 
+      return commands[keyword]; 
+    } 
+    else 
+    { 
+      //didn't find command 
+      for(let index in commands) 
+      { 
+        if(commands[index] && typeof commands[index] === 'object'
+           && commands[index].getAlias().indexOf(keyword) > -1) 
+        { 
+          return commands[index]; 
+        } 
+      } 
+    } 
+    return null; 
+  }; 
+  
   utilities.red = 0xFF0000;
   utilities.green = 0x25bf06;
   return utilities;

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -126,8 +126,7 @@ module.exports = (requires) => {
   };
 
   //for finding the command object for either the keyword or an alias 
-  utilities.getCommand = function(keyword) 
-  { 
+  utilities.getCommand = (keyword) => { 
     let commands = info.commands;
     if(commands[keyword] && typeof commands[keyword].getAction() === 'function') { 
       return commands[keyword]; 
@@ -143,21 +142,22 @@ module.exports = (requires) => {
     return null; 
   };
 
-  utilities.getPermLevel = function(details) {
-    let db = info.db;
-    let roles = details.member ? details.member.roles : [];
-    let permLevel = 'public';
-    if(details.isAdministrator) {
-      permLevel = 'private';
-    } else {
-      permLevel = db.findPerm(details.userId, roles).then(perm => {
-        if(perm != null) {
-          return perm._id;
-        }
-        return 'public';
-      }).catch(console.log);
-    }
-    return permLevel;
+  utilities.getPermLevel = (details) => {
+    return new Promise((resolve, reject) => {
+      let db = info.bd;
+      let roles = details.member ? details.member.roles : [];
+      if(details.isAdministrator) {
+        resolve('private');
+      } else {
+        db.findPerm(details.userId, roles).then(perm => {
+          if(perm != null) {
+            resolve(perm._id);
+          } else {
+            resolve('public');
+          }
+        }).catch(console.log);
+      }
+    });
   };
 
   utilities.hasPermission = (commandLevel, userLevel) => {

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -160,19 +160,30 @@ module.exports = (requires) => {
     return permLevel;
   };
 
-  utilities.hasPermission = function(commandLevel, userLevel) {
-    // private privilege (administrator) can execute any command
-    // public commands can be executed by anyone
-    if(userLevel === 'private' || commandLevel === 'public') {
+  utilities.hasPermission = (commandLevel, userLevel) => {
+    switch (userLevel) {
+    case 'private':
       return true;
+    case 'high':
+      if(commandLevel != 'private') {
+        return true;
+      }
+      break;
+    case 'low':
+      if(commandLevel === 'low' || commandLevel === 'public'){
+        return true;
+      }
+      break;
+    case 'public':
+      if(commandLevel === 'public') {
+        return true;
+      }
+      break;
     }
-    // now 'high' and 'low' remain
-    // 'high' can execute both 'high' and 'low' commands
-    // commands that are 'low' can be used by both
-    if(userLevel === 'high' || commandLevel === 'low'){
-      return true;
-    }
-    return false;
+    // there is no `default` above, but if somehow `userLevel` is
+    // not one of the expected strings, it'll still fallback here
+    // and default to false
+    return false;    
   };
   
   utilities.red = 0xFF0000;

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -144,7 +144,7 @@ module.exports = (requires) => {
 
   utilities.getPermLevel = (details) => {
     return new Promise((resolve, reject) => {
-      let db = info.bd;
+      let db = info.db;
       let roles = details.member ? details.member.roles : [];
       if(details.isAdministrator) {
         resolve('private');

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -147,7 +147,17 @@ module.exports = (requires) => {
       } 
     } 
     return null; 
-  }; 
+  };
+
+  utilities.hasPermission = function(commandPerm, userLevel) {
+    // 'high' can execute both 'high' and 'low' commands
+    // commands that are 'low' can be used no matter one's permission level
+    if(userLevel === 'high' || commandLevel === 'low') {
+      return true;
+    } else {
+      return false;
+    }
+  };
   
   utilities.red = 0xFF0000;
   utilities.green = 0x25bf06;

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -149,10 +149,10 @@ module.exports = (requires) => {
     return null; 
   };
 
-  utilities.hasPermission = function(commandPerm, userLevel) {
-    // 'high' can execute both 'high' and 'low' commands
+  utilities.hasPermission = function(commandLevel, userLevel) {
+    // 'high' can execute both 'high' and 'low' commands, but not 'private'
     // commands that are 'low' can be used no matter one's permission level
-    if(userLevel === 'high' || commandLevel === 'low') {
+    if((userLevel === 'high' && commandLevel != 'private')  || commandLevel === 'low'){
       return true;
     } else {
       return false;

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -128,25 +128,36 @@ module.exports = (requires) => {
   //for finding the command object for either the keyword or an alias 
   utilities.getCommand = function(keyword) 
   { 
-    let commands = info.commands; 
-    //if the command exists, check the permissions. 
-    if(commands[keyword] && typeof commands[keyword].getAction() === 'function') 
-    { 
+    let commands = info.commands;
+    if(commands[keyword] && typeof commands[keyword].getAction() === 'function') { 
       return commands[keyword]; 
-    } 
-    else 
-    { 
+    } else { 
       //didn't find command 
-      for(let index in commands) 
-      { 
+      for(let index in commands) { 
         if(commands[index] && typeof commands[index] === 'object'
-           && commands[index].getAlias().indexOf(keyword) > -1) 
-        { 
+           && commands[index].getAlias().indexOf(keyword) > -1) { 
           return commands[index]; 
         } 
       } 
     } 
     return null; 
+  };
+
+  utilities.getPermLevel = function(details) {
+    let db = info.db;
+    let roles = details.member ? details.member.roles : [];
+    let permLevel = 'public';
+    if(details.isAdministrator) {
+      permLevel = 'private';
+    } else {
+      permLevel = db.findPerm(details.userId, roles).then(perm => {
+        if(perm != null) {
+          return perm._id;
+        }
+        return 'public';
+      }).catch(console.log);
+    }
+    return permLevel;
   };
 
   utilities.hasPermission = function(commandLevel, userLevel) {

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -150,13 +150,18 @@ module.exports = (requires) => {
   };
 
   utilities.hasPermission = function(commandLevel, userLevel) {
-    // 'high' can execute both 'high' and 'low' commands, but not 'private'
-    // commands that are 'low' can be used no matter one's permission level
-    if((userLevel === 'high' && commandLevel != 'private')  || commandLevel === 'low'){
+    // private privilege (administrator) can execute any command
+    // public commands can be executed by anyone
+    if(userLevel === 'private' || commandLevel === 'public') {
       return true;
-    } else {
-      return false;
     }
+    // now 'high' and 'low' remain
+    // 'high' can execute both 'high' and 'low' commands
+    // commands that are 'low' can be used by both
+    if(userLevel === 'high' || commandLevel === 'low'){
+      return true;
+    }
+    return false;
   };
   
   utilities.red = 0xFF0000;

--- a/src/structures/Bot.js
+++ b/src/structures/Bot.js
@@ -212,9 +212,8 @@ class Bot extends EventEmitter {
           }
           if(docs != null) {
             details.permissionLevel = docs._id;
-            if(permLevel === 'low' && (docs._id === 'low' || docs._id === 'high')) {
-              command.act(details);
-            } else if (permLevel === 'high' && (docs._id === 'high')) {
+            if(utility.hasPerm(permLevel, docs._id)) {
+              details.permissionLevel = docs._id;
               command.act(details);
             }
           }

--- a/src/structures/Bot.js
+++ b/src/structures/Bot.js
@@ -177,21 +177,14 @@ class Bot extends EventEmitter {
     let cmd = utility.stripPrefix(details.message);
     let keyword = cmd.split(' ')[0];
     details.input = cmd.replace(keyword, '').trim();
-
+    
     //split up the remaining into something similar to command line args
     details.args = cmd.split(' ');
     keyword = keyword.toLowerCase();
-    
-    //if the command exists, check the permissions.
-    if(commands[keyword] && typeof commands[keyword].getAction() === 'function') {
+
+    let command = utility.getCommand(keyword);
+    if(command != null) {
       processCommand(keyword, details, db);
-    } else {
-      //didn't find command
-      for(let index in commands) {
-        if(commands[index] && typeof commands[index] === 'object' && commands[index].getAlias().indexOf(keyword) > -1) {
-          processCommand(index, details, db);
-        }
-      }
     }
     
     function handleDisabled(details) {
@@ -203,45 +196,46 @@ class Bot extends EventEmitter {
         }
       });
     }
+    
     function processCommand(command, details, db) {
-      const permLevel = commands[command].getPerm();
+      const permLevel = command.getPerm();
       if(permLevel === 'public') {
-        commands[command].act(details);
+        command.act(details);
       } else if(permLevel === 'private' && details.isAdministrator) {
-        commands[command].act(details);
+        command.act(details);
       } else if(permLevel === 'high' || permLevel === 'low') {
         if(!details.member) {
           db.findPerm(details.userID, []).then(docs => {
             if(docs === null) {
               if(details.isAdministrator) {
-                commands[command].act(details);
+                command.act(details);
               }
               return;
             } else {
               details.permissionLevel = docs._id;
               if(permLevel === 'low' && (docs._id === 'low' || docs._id === 'high' || details.isAdministrator)) {
-                commands[command].act(details);
+                command.act(details);
               } else if (permLevel === 'high' && (docs._id === 'high' || details.isAdministrator)) {
-                commands[command].act(details);
+                command.act(details);
               }
             }
-          }).catch(console.log)
+          }).catch(console.log);
         } else {
           db.findPerm(details.userID, details.member.roles).then(docs => {
             if(docs === null) {
               if(details.isAdministrator) {
-                commands[command].act(details);
+                command.act(details);
               }
               return;
             } else {
               details.permissionLevel = docs._id;
               if(permLevel === 'low' && (docs._id === 'low' || docs._id === 'high' || details.isAdministrator)) {
-                commands[command].act(details);
+                command.act(details);
               } else if (permLevel === 'high' && (docs._id === 'high' || details.isAdministrator)) {
-                commands[command].act(details);
+                command.act(details);
               }
             }
-          }).catch(console.log)
+          }).catch(console.log);
         }
       }
     }

--- a/src/structures/Bot.js
+++ b/src/structures/Bot.js
@@ -204,40 +204,23 @@ class Bot extends EventEmitter {
       } else if(permLevel === 'private' && details.isAdministrator) {
         command.act(details);
       } else if(permLevel === 'high' || permLevel === 'low') {
-        if(!details.member) {
-          db.findPerm(details.userID, []).then(docs => {
-            if(docs === null) {
-              if(details.isAdministrator) {
-                command.act(details);
-              }
-              return;
-            } else {
-              details.permissionLevel = docs._id;
-              if(permLevel === 'low' && (docs._id === 'low' || docs._id === 'high' || details.isAdministrator)) {
-                command.act(details);
-              } else if (permLevel === 'high' && (docs._id === 'high' || details.isAdministrator)) {
-                command.act(details);
-              }
+        let roles = details.member ? details.member.roles : [];
+        db.findPerm(details.userID, roles).then(docs => {
+          if(details.isAdministrator) {
+            command.act(details);
+            return;
+          }
+          if(docs != null) {
+            details.permissionLevel = docs._id;
+            if(permLevel === 'low' && (docs._id === 'low' || docs._id === 'high')) {
+              command.act(details);
+            } else if (permLevel === 'high' && (docs._id === 'high')) {
+              command.act(details);
             }
-          }).catch(console.log);
-        } else {
-          db.findPerm(details.userID, details.member.roles).then(docs => {
-            if(docs === null) {
-              if(details.isAdministrator) {
-                command.act(details);
-              }
-              return;
-            } else {
-              details.permissionLevel = docs._id;
-              if(permLevel === 'low' && (docs._id === 'low' || docs._id === 'high' || details.isAdministrator)) {
-                command.act(details);
-              } else if (permLevel === 'high' && (docs._id === 'high' || details.isAdministrator)) {
-                command.act(details);
-              }
-            }
-          }).catch(console.log);
-        }
+          }
+        }).catch(console.log);
       }
+       
     }
   }
   /**

--- a/src/structures/Bot.js
+++ b/src/structures/Bot.js
@@ -200,9 +200,14 @@ class Bot extends EventEmitter {
     
     function processCommand(command, details, db) {
       const commandLevel = command.getPerm();
-      details.permissionLevel = utility.getPermLevel(details);
-      if(utility.hasPermission(commandLevel, details.permissionLevel)) {
+      if (commandLevel === 'public') {
         command.act(details);
+      } else {
+        utility.getPermLevel(details).then((userLevel) => {
+          if(utility.hasPermission(commandLevel, userLevel)) {
+            command.act(details);
+          }
+        }).catch(console.log);
       }
     }
   }

--- a/src/structures/Command.js
+++ b/src/structures/Command.js
@@ -31,8 +31,8 @@ class Command
     this.name = settings.name;
     this.alias = settings.alias;
     this.blurb = settings.blurb; 
-    this.longDescription = settings.longDescription; 
-    this.usages = settings.usages; 
+    this.longDescription = settings.longDescription || "No description"; 
+    this.usages = settings.usages || []; 
     this.action = settings.action;
     this.bot = requires.bot;
     this.info = requires.info;

--- a/src/structures/Command.js
+++ b/src/structures/Command.js
@@ -13,10 +13,12 @@ class Command
    * @param {Object} settings - Object that holds the settings for the class.
    * @param {String} settings.name - Name of the command.
    * @param {Array<String>} settings.alias - Array of strings that are accepted as an alias/aliases.
-   * @param {String} settings.description - Description of the command.
+   * @param {String} settings.blurb - Short description of the command. 
+   * @param {String} settings.longDescription - Longer description with usage details. 
+   * @param {Array<String>} settings.usages - Example of different usages of the command
    * @param {function} settings.action - Function that the command will perform.
    * @param {String} [settings.permission = public] - Permission to be set, defaults to public.
-   * @param {Boolean} [settings.inline = true] - Boolean for making the command's description appear inline
+   * @param {Boolean} [settings.inline = true] - Boolean for making the command's blurb appear inline 
    * @param {Object} requires - Object that holds the required objects for the command.
    * @param {Object} requires.bot - D.io client instance.
    * @param {Object} requires.info - Needed info from the bot, plugins, etc.
@@ -28,7 +30,9 @@ class Command
     //required
     this.name = settings.name;
     this.alias = settings.alias;
-    this.description = settings.description;
+    this.blurb = settings.blurb; 
+    this.longDescription = settings.longDescription; 
+    this.usages = settings.usages; 
     this.action = settings.action;
     this.bot = requires.bot;
     this.info = requires.info;


### PR DESCRIPTION
Adds the ability to get details specific commands with `!help {command}`. Commands now have both a `blurb` (equivalent to the previous `description`, meant to be short) and a `longDescription` with more details and notes. There is also a `usages` array that can have info on different usages separately and is displayed alongside the descriptions. Both `longDescription` and `usages` are optional as far as the help command is concerned.

This also includes a considerable refactor of `processCommand` both to make it more readable and to extract functionality that is being used in multiple places, including
- adding a `getCommand` function to utility.js, which can find the specific command object given either the command's name or any of its aliases. This functionality was useful for both the help command and main bot functionality and they now can share this bit of code.
- refactoring permission-checking code into `getPermLevel` and `hasPermission` functions in utility.js. The former gets `details` to determine the user's perm level. Administrators are assigned the perm level `private` to make the rest of the code simpler and not have to constantly check for administrator rights separate from permissions. `hasPermission` compares the permission requirements of a command with that of the user to check that they can execute it. These functionalities were useful for both the Bot structure and the help command code
- given the above change to refer to admin privileges through a permission string, the permission level is now added to `details` in all cases so that it can be relied on consistently by the command. Previously it was not used for administrators.

I haven't yet checked if the new functions mentioned above can be used outside of the `onMessage` event and the help command, though I plan to do so some other time to make the code overall more consistent.
Also, not all commands (particularly staff-facing ones) have full descriptions and usage notes yet. I'll be looking into writing them soon.