### PR TITLE
Implemented reading squad automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
  node start.js
  ```
 
- If using VSCode, just open the project root and press F5
-
 You can just create an empty feathers.json file in the root of the project and it will be populated automatically.
 
 Here is an example `config.json` file as well:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
  node start.js
  ```
 
-You can just create an empty feathers.json file in the root of the project.
+ If using VSCode, just open the project root and press F5
+
+You can just create an empty feathers.json file in the root of the project and it will be populated automatically.
 
 Here is an example `config.json` file as well:
 ```
@@ -22,6 +24,8 @@ Here is an example `config.json` file as well:
   "log_channel":"",
   "voice_channel": "",
   "voice_channel_chat": "",
+  "reading_role": "",
+  "reading_reports_channel": "",
   "api": {
     "discord_token": "<bot token>"
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "debug": "node start.js"
   },
   "repository": {
     "type": "git",

--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -1,0 +1,8 @@
+{
+    "name": "Launch via npm",
+    "type": "node",
+    "request": "launch",
+    "cwd": "${workspaceFolder}",
+    "runtimeExecutable": "npm",
+    "runtimeArgs": ["run-script", "debug"]
+  }

--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -1,8 +1,0 @@
-{
-    "name": "Launch via npm",
-    "type": "node",
-    "request": "launch",
-    "cwd": "${workspaceFolder}",
-    "runtimeExecutable": "npm",
-    "runtimeArgs": ["run-script", "debug"]
-  }

--- a/src/commands/initReadingSquad.js
+++ b/src/commands/initReadingSquad.js
@@ -1,0 +1,36 @@
+'use strict';
+const Command = require('../structures/Command');
+
+//Adds a pencil at the end of your nickname or username.
+module.exports = function command(requires)
+{
+  return new Command({
+    name: 'InitReadingSquad',
+    inline: true,
+    alias: ['squadup'],
+    blurb: 'Set up reading squad deadline',
+    longDescription: 'Schedules the first deadline for the Reading Squad. Future deadlines will be scheduled automatically.',
+    usages: ['`%prefixsquadup`'],
+    permission: 'low',
+    action: function(details)
+    {
+      let bot = requires.bot;
+      let info = requires.info;
+      let readingSquad = info.utility.useSource('readingSquad');
+
+      info.db.countTimers('reading').then(count => {
+        if (count == 0) {
+          const deadline = readingSquad.setUpcomingDeadline();
+          bot.createMessage(details.channelID, {embed: {
+            title: 'Success', description: `Reading Squad deadline set to ${deadline.toUTCString()}`}
+          });
+        }
+        else {
+          bot.createMessage(details.channelID, {embed: {
+            title: 'Error', description: 'Reading squad deadline is already set', color: info.utility.red}
+          });
+        }
+      });
+    }
+  }, requires);
+};

--- a/src/feathers/readingSquad/readingSquad.js
+++ b/src/feathers/readingSquad/readingSquad.js
@@ -1,0 +1,74 @@
+//Feather for reading squad services
+'use strict';
+module.exports = function feather(requires)
+{
+  //feather obj
+  const feather = {};
+  
+  //requires
+  const { bot, info } = requires;
+
+  //feather functions
+  feather.reset = function() {
+    postResetMessage()
+      .then(() => getMembersToClear())
+      .then(expiredMembers => clearRoles(expiredMembers))
+      .then(() => info.db.clearReadingSquad())
+      .then(() => feather.setUpcomingDeadline());
+  }
+
+  feather.approve = function(member) {
+    if (member) {
+      if (!member.roles.includes(info.config.reading_role)) {
+        member.addRole(info.config.reading_role, 'Reading report approved');
+      }
+      info.db.addToReadingSquad(member.id);
+    }
+  }
+
+  feather.setUpcomingDeadline = function() {
+    const deadline = getUpcomingDeadline();
+    info.db.addTimer(null, 'reading', deadline);
+    return deadline;
+  }
+
+  //helper functions
+  function postResetMessage() {
+    return bot.createMessage(info.config.reading_reports_channel, {embed: {
+      title: 'It is now Tuesday 00:00 JST (Monday 15:00 UTC), which means a new week has started.',
+      description: `Anyone who posted a report last week that doesn't post a new report until the same time next week will lose the Reading Squad 🔥🔥 role.\n\nRoles will be cleared from people who didn't post a report last week now.`,
+      color: info.utility.readingSquadCoolBlue}
+    });
+  }
+
+  function getMembersToClear() {
+    return info.db.listApprovedReadingSquad().then(approvedIDs => {
+      //  get all users with the reading squad role
+      const server = bot.guilds.get(info.settings.home_server_id);
+      const currentSquad = server.members.filter(x => x.roles.includes(info.config.reading_role));
+
+      //  get ids of users who didn't post a report this week
+      return currentSquad.filter(x => !approvedIDs.includes(x.id));
+    });
+  }
+
+  function clearRoles(expiredMembers) {
+    //  remove roles from people who didn't post a report
+    const squadRole = info.config.reading_role;
+    for (const member of expiredMembers) {
+        member.removeRole(squadRole, 'Reading report expired');
+    }
+  }
+
+  function getUpcomingDeadline() {
+    const deadline = new Date();
+    deadline.setUTCHours(15); //  15 UTC = midnight in Japan
+    deadline.setUTCMinutes(0);
+    deadline.setUTCSeconds(0);
+    deadline.setUTCMilliseconds(0);
+    deadline.setUTCDate(deadline.getUTCDate() + (7 - (deadline.getUTCDay() - 1))) //  upcoming Monday
+    return deadline;
+  }
+
+  return feather;
+};

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -250,6 +250,16 @@ module.exports = function utility(requires) {
       });
     });
   }
+  db.countTimers = (type) => {
+    return new Promise((resolve, reject) => {
+      db.timers.count({type}, (err, docs) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(docs);
+      })
+    })
+  };
   db.getUserTimer = (userID) => {
     return new Promise((resolve, reject) => {
       db.timers.find({ userID }, (err, docs) => {
@@ -299,7 +309,7 @@ module.exports = function utility(requires) {
     });
   }
   /**
-   * DB setup for infractions
+   * DB setup for settings
    */
   db.settings = new Datastore('./src/lib/databases/settings.db');
   db.settings.loadDatabase();
@@ -335,5 +345,45 @@ module.exports = function utility(requires) {
       })
     })
   }
+
+  /**
+   * DB setup for reading squad
+   */
+  db.readingSquad = new Datastore('./src/lib/databases/readingSquad.db');
+  db.readingSquad.loadDatabase();
+  db.readingSquad.ensureIndex({ fieldName: 'userID', unique: true });
+  //autocompaction every 10 minutes: _id is the user id
+  db.readingSquad.persistence.setAutocompactionInterval(600000);
+  db.addToReadingSquad = (userID) => {
+    return new Promise((resolve, reject) => {
+      db.readingSquad.insert({userID}, (err, docs) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(docs);
+      });
+    });
+  }
+  db.listApprovedReadingSquad = () => {
+    return new Promise((resolve, reject) => {
+      db.readingSquad.find({}, (err, docs) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(docs.map(x => x.userID));
+      });
+    });
+  }
+  db.clearReadingSquad = () => {
+    return new Promise((resolve, reject) => {
+      db.readingSquad.remove({}, { multi: true }, (err, docs) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(docs);
+      });
+    });
+  }
+
   return db;
 };

--- a/src/lib/handleTimer.js
+++ b/src/lib/handleTimer.js
@@ -2,9 +2,6 @@ module.exports = (requires) => {
   const { info, bot } = requires;
 
   const handler = {};
-  function searchForMuted(roles) {
-    roles.includes(info.settings.mute_role_id)
-  }
   function unmuteUser(userID) {
     const user = bot.guilds.get(info.settings.home_server_id).members.get(userID);
     if(user !== undefined) {
@@ -15,11 +12,19 @@ module.exports = (requires) => {
       }
     }
   }
+  function resetReadingSquad() {
+    const readingSquad = info.utility.useSource('readingSquad');
+    readingSquad.reset();
+  }
   function processPassed(passed) {
     passed.forEach(timer => {
       switch(timer.type) {
         case 'mute':
           unmuteUser(timer.userID);
+          break;
+        case 'reading':
+          resetReadingSquad();
+          break;
       }
     });
   }
@@ -28,7 +33,7 @@ module.exports = (requires) => {
     //console.log('tick');
     info.db.findPassed(now).then(passedTimers => {
       processPassed(passedTimers);
-      // do something, then delet passed Timers
+      // do something, then delete passed Timers
       info.db.removePassed(now).then(numRemoved => {
         //console.log(numRemoved);
       }).catch(console.log);

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -188,5 +188,6 @@ module.exports = (requires) => {
   
   utilities.red = 0xFF0000;
   utilities.green = 0x25bf06;
+  utilities.readingSquadCoolBlue = 0x0CCDD3
   return utilities;
 };

--- a/src/structures/Bot.js
+++ b/src/structures/Bot.js
@@ -118,10 +118,7 @@ class Bot extends EventEmitter {
     if(this.debug) {
       bot.on('debug', this.onDebug.bind(this));
     }
-    if (this.config.reading_role && this.config.reading_reports_channel) {
-      bot.on('messageReactionAdd', this.onReadingReportReaction.bind(this));
-    }
-
+    
     bot.on('guildDelete', (server) => {
       console.log(`Left ${server}`);
     });
@@ -228,31 +225,6 @@ class Bot extends EventEmitter {
       console.log('Kill command used.');
       process.exit(0);
     }
-  }
-
-  /**
-   * Handles reactions in the reading report channel
-   * @param {*} message The message that was reacted to
-   * @param {*} emoji The that was used as a reaction
-   */
-  onReadingReportReaction(message, emoji) {
-    //  only process reactions in the reading reports channel
-    if (message.channel.id !== this.config.reading_reports_channel)
-      return;
-
-    //  only process the checkmark emoji
-    if (emoji.name !== '✅')
-      return;
-
-    const utility = this.requires.utility;
-    this.client.getMessage(message.channel.id, message.id).then(fullMessage => {
-      const checks = fullMessage.reactions['✅'] || { count: 0};
-      if (checks.count != 1)
-        return; //  only take action the first time somebody reacts
-      
-      const readingSquad = utility.useSource('readingSquad');
-      readingSquad.approve(fullMessage.member);
-    });
   }
   /**
    * Handles debug events for the lib/bot itself.


### PR DESCRIPTION
- add new config properties "reading_role" and "reading_reports_channel"
- add vscode launch file and node script to run
- add new readingSquad feather to provide common functionality
-- add Reading Squad role on checkmark emoji react
-- remove Reading Squad role on report expiration
-- handle new 'reading' timer type
-- post weekly alert in reading reports channel
- add new command InitReadingSquad to seed the database on first run
- add new Datastore to track reading squad membership
- add timers datastore method to count timers of a given type
- add 'messageReactionAdd' event handler to bot (only for report channel